### PR TITLE
Only rerun GHA validation on PR changes or base branch edit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Check Linting has been applied
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   lint:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,8 +1,8 @@
 name: Check Prettier formatting has been applied
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   prettier:


### PR DESCRIPTION
At the moment the push and pull_request trigger parallel linting checks. This change will only trigger the linting on PR changes or changes to the base branch e.g. main.