### PR TITLE
[DEVOP-881] github update all action workflows to use actions artifac…

### DIFF
--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -11,10 +11,10 @@ jobs:
       RELEASE_BRANCH_PREFIX: 'container/'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -38,7 +38,7 @@ jobs:
           PKG_HOWTOS_PATH: ${{ github.ref_name }}
 
       - name: Upload artifacts (GitHub Pages)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: workflow-howtos-github
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload artifacts (AWS s3 CDN)
         if: ${{ startsWith(github.ref_name, env.RELEASE_BRANCH_PREFIX) }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: workflow-howtos-aws
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: workflow-howtos-github
           path: public-github/
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: workflow-howtos-aws
           path: public-aws/


### PR DESCRIPTION
…t v4 plugins

Starting November 30, 2024, workflows using actions/upload-artifact@v3 & actions/download-artifact@v3 will no longer function. The v4 release offers significant performance improvements, including up to 98% faster upload and download speeds, and introduces new features.

The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-node@v3, actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/