### PR TITLE
How to warn before closing dialog: use textContent instead of innerHTML

### DIFF
--- a/how-to/use-platform/warn-before-closing-dialog/client/src/dialog.ts
+++ b/how-to/use-platform/warn-before-closing-dialog/client/src/dialog.ts
@@ -27,7 +27,7 @@ function populatePreventedViews(views: { name: string }[]): void {
 	for (const view of views) {
 		console.log("add view", view);
 		const viewP = document.createElement("p");
-		viewP.innerHTML = view.name;
+		viewP.textContent = view.name;
 		const v = document.querySelector("#views");
 		if (v) {
 			v.append(viewP);
@@ -44,7 +44,7 @@ function populate(): void {
 
 	if (closeType === "view") {
 		const p = document.createElement("p");
-		p.innerHTML = "Are you sure you want to close this view? It may have unsaved changes.";
+		p.textContent = "Are you sure you want to close this view? It may have unsaved changes.";
 		const t = document.querySelector("#text");
 		if (t) {
 			t.append(p);
@@ -55,14 +55,14 @@ function populate(): void {
 		const views = JSON.parse(params.get("views") ?? "").views;
 
 		const p1 = document.createElement("p");
-		p1.innerHTML = "Are you sure you want to close this window?";
+		p1.textContent = "Are you sure you want to close this window?";
 		const t1 = document.querySelector("#text");
 		if (t1) {
 			t1.append(p1);
 		}
 
 		const p2 = document.createElement("p");
-		p2.innerHTML = "The following views may have unsaved changes:";
+		p2.textContent = "The following views may have unsaved changes:";
 		const t2 = document.querySelector("#text");
 		if (t2) {
 			t2.append(p2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3613,18 +3613,6 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/@types/yauzl": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "7.18.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -4977,15 +4965,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
-		},
-		"node_modules/bare-events": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-			"integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -7193,18 +7172,6 @@
 			},
 			"optionalDependencies": {
 				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/escodegen/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/eslint": {


### PR DESCRIPTION
Resolve a High-level vulnerability by using textContent instead of innerHTML for displaying certain information. Only had to change one of the innerHTML uses to textContent but wanted to be consistent.